### PR TITLE
Support colorTemperature

### DIFF
--- a/packageManifest.json
+++ b/packageManifest.json
@@ -2,10 +2,10 @@
 	"packageName": "Switch Bindings",
 	"minimumHEVersion": "2.2.1",
 	"author": "Joel Wetzel",
-	"version": "1.1",
-	"dateReleased": "2020-09-27",
+	"version": "1.11",
+	"dateReleased": "2021-01-20",
 	"licenseFile": "https://raw.githubusercontent.com/joelwetzel/Hubitat-Auto-Shades/master/LICENSE",
-	"releaseNotes": "Added more debug logging.",
+	"releaseNotes": "Added color temperature support.",
 	"communityLink": "https://community.hubitat.com/t/release-switch-bindings",
 	"documentationLink": "https://github.com/joelwetzel/Hubitat-Switch-Bindings",
 	"apps" : [


### PR DESCRIPTION
Thanks for this app; I'm brand new to Hubitat and it's been solving a bunch of my setup without more complicated rules.

I have four HALO RL56 lights that only support colortemp not full RGB and wanted to put them in a group with a virtual CT switch so I could control them as a unit from Alexa and still maintain level control with a smart switch. I tested this commit by creating a binding the lights, the dimmer switch (ZEN22 in "smart light" mode), and a Virtual CT dimmer.

Color temp and level changes from Alexa or by directly adjusting any of the lights/virtual switch work and the physical smart switch controls just the level. Let me know if you want me to tweak this PR.